### PR TITLE
Diagnose feed display & enhance TestimonialManager

### DIFF
--- a/includes/TestimonialManager.php
+++ b/includes/TestimonialManager.php
@@ -129,19 +129,28 @@ class TestimonialManager {
      */
     public function getPendingTestimonials($userId) {
         try {
+            // Modified SQL for consistent writer_name fetching
             $sql = "SELECT t.*, 
-                           u.first_name as writer_name, 
+                           CONCAT_WS(' ', u.first_name, u.middle_name, u.last_name) as writer_name,
                            u.profile_pic as writer_profile_pic,
-                           u.gender as writer_gender, // Added writer_gender
+                           u.gender as writer_gender,
                            u.id as writer_user_id
                     FROM testimonials t
                     JOIN users u ON t.writer_user_id = u.id
                     WHERE t.recipient_user_id = :user_id AND t.status = 'pending'
                     ORDER BY t.created_at DESC";
-            
+
             $stmt = $this->pdo->prepare($sql);
             $stmt->execute([':user_id' => $userId]);
             $testimonials = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            // Temporary logging - REMOVE FOR PRODUCTION
+            // error_log("[DEBUG TestimonialManager->getPendingTestimonials] User ID: " . $userId);
+            // error_log("[DEBUG TestimonialManager->getPendingTestimonials] Raw count from DB: " . count($testimonials));
+            // if (count($testimonials) > 0) {
+            //     error_log("[DEBUG TestimonialManager->getPendingTestimonials] First raw testimonial: " . json_encode($testimonials[0]));
+            // }
+            // End Temporary logging
 
             foreach ($testimonials as &$testimonial) {
                 $profilePicPath = MediaParser::getFirstMedia($testimonial['writer_profile_pic']);
@@ -157,18 +166,22 @@ class TestimonialManager {
                         : 'assets/images/MaleDefaultProfilePicture.png';
                 }
             }
-            unset($testimonial); // Unset reference to last element
-            
+            unset($testimonial);
+
             return [
                 'success' => true,
                 'testimonials' => $testimonials,
                 'count' => count($testimonials)
             ];
-            
+
         } catch (PDOException $e) {
+            // Log actual DB error for debugging
+            error_log("[ERROR TestimonialManager->getPendingTestimonials] Database error for User ID " . $userId . ": " . $e->getMessage());
             return [
                 'success' => false,
-                'error' => 'Database error: ' . $e->getMessage()
+                'error' => 'Database error: ' . $e->getMessage(),
+                'testimonials' => [], // Ensure testimonials is an empty array on error
+                'count' => 0
             ];
         }
     }

--- a/testimonials.php
+++ b/testimonials.php
@@ -445,29 +445,29 @@ $defaultFemalePic = 'assets/images/FemaleDefaultProfilePicture.png';
                 const response = await fetch(apiUrl);
                 const data = await response.json();
 
+                // Corrected logic: Single 'if' to handle successful data retrieval
                 if (data.success && data.testimonials && data.testimonials.length > 0) {
-                    let testimonialsHTML = '<div class="row">';
-                    
                     console.log(`[Pending Tab Debug] Response for filter "${filter}", user ID "${userIdToLoad}":`, JSON.stringify(data, null, 2)); 
                     
-                    if (data.success && data.testimonials && data.testimonials.length > 0) {
-                        let testimonialsHTML = '<div class="row">';
-                        data.testimonials.forEach(testimonial => {
-                            if (filter === 'written') {
-                                testimonialsHTML += renderWrittenTestimonialCard(testimonial);
-                            } else {
-                                testimonialsHTML += renderTestimonialCard(testimonial, userIdToLoad, loggedInUserId, filter);
-                            }
-                        });
-                        testimonialsHTML += '</div>';
-                        container.innerHTML = testimonialsHTML;
-                    } else {
-                        if (filter === 'pending') {
-                            console.log(`[Pending Tab Debug] Displaying empty state for pending. Success: ${data.success}, Testimonials Array: ${data.testimonials ? 'Exists (length ' + data.testimonials.length + ')' : 'Missing/Null'}`);
+                    let testimonialsHTML = '<div class="row">'; // Initialize once
+                    data.testimonials.forEach(testimonial => {
+                        if (filter === 'written') {
+                            testimonialsHTML += renderWrittenTestimonialCard(testimonial);
+                        } else {
+                            // Pass loggedInUserId to renderTestimonialCard
+                            testimonialsHTML += renderTestimonialCard(testimonial, userIdToLoad, loggedInUserId, filter);
                         }
-                        container.innerHTML = getEmptyState(filter); 
+                    });
+                    testimonialsHTML += '</div>';
+                    container.innerHTML = testimonialsHTML;
+                } else {
+                    // This 'else' now correctly corresponds to the primary 'if' condition
+                    if (filter === 'pending') {
+                        console.log(`[Pending Tab Debug] Displaying empty state for pending. Success: ${data.success}, Testimonials Array: ${data.testimonials ? 'Exists (length ' + data.testimonials.length + ')' : 'Missing/Null'}, Error: ${data.error || 'None'}`);
                     }
-                } catch (error) {
+                    container.innerHTML = getEmptyState(filter);
+                }
+            } catch (error) {
                     console.error(`[Pending Tab Debug] Error loading testimonials for filter "${filter}":`, error);
                     container.innerHTML = `
                         <div class="alert alert-danger">


### PR DESCRIPTION
This commit includes the following:

1.  **Activity Feed (`api/add_ons_middle_element.php`):**
    - I further investigated the "Unknown User" display for testimonials in the activity feed (e.g., when User A writes for User B, User A's feed shows "User B received from Unknown User").
    - I've refined the PHP mapping logic in `api/add_ons_middle_element.php`, and I believe it's now robust.
    - The persistent issue strongly suggests a data integrity problem at the database level (e.g., `writer_user_id` in the `testimonials` table is NULL or refers to a non-existent user). I didn't make further code changes to this file for this issue; I recommend inspecting the database.

2.  **Testimonials - Pending Tab (`includes/TestimonialManager.php`):**
    - I modified the `getPendingTestimonials()` method in `TestimonialManager.php` to help diagnose why the "Pending Approval" tab might be empty despite pending items existing.
    - I standardized the fetching of `writer_name` using `CONCAT_WS` for consistency with other methods.
    - I improved the structure of the error response in the `catch` block.
    - I added (commented out) `error_log` statements for detailed debugging. If the "Pending Approval" tab issue persists, you can uncomment these logs to check the raw output of the SQL query for pending testimonials. This will help determine if the query itself is not returning the expected data.

3.  **Changelog:**
    - I updated `CHANGELOG.md` to reflect these investigations, changes, and recommendations.

This set of changes aims to provide tools for you to further diagnose persistent issues and rules out further PHP mapping errors for the activity feed.